### PR TITLE
SkeletonPost 컴포넌트 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,8 @@ function App() {
         setPosts(pages.flatMap(({ data }: { data: PostType[] }) => {
           return data
         }))
-      }
+      },
+      refetchOnWindowFocus: false
     }
   )
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import GridPosts from './components/Post/GridPosts';
 function App() {
   const [ref, inView, entry] = useInView()
   const [posts, setPosts] = useState<PostType[]>([])
-  const { fetchNextPage, hasNextPage } = useInfiniteQuery(
+  const { isFetching, fetchNextPage, hasNextPage } = useInfiniteQuery(
     ['infinitePerson'],
     async ({ pageParam = 1 }) => {
       const res = await HttpInstance.getInfinitePosts(pageParam, pagePerLimitPosts)
@@ -44,7 +44,7 @@ function App() {
   return (
     <>
       <h3>Posts</h3>
-      <GridPosts posts={posts} bottomRef={ref} />
+      <GridPosts posts={posts} bottomRef={ref} isFetching={isFetching} />
     </>
   )
 }

--- a/src/components/Post/GridPosts.tsx
+++ b/src/components/Post/GridPosts.tsx
@@ -1,8 +1,9 @@
 import { PostType } from '../../utils/types';
 import Post from './Post';
 import './GridPost.scss'
+import SkeletonPost from '../Skeleton/SkeletonPost';
 
-const GridPosts = ({ posts, bottomRef }: { posts: PostType[], bottomRef: any }) => {
+const GridPosts = ({ posts, bottomRef, isFetching }: { posts: PostType[], bottomRef: any, isFetching: boolean }) => {
   return (
     <div className="posts-wrapper">
       {
@@ -10,6 +11,7 @@ const GridPosts = ({ posts, bottomRef }: { posts: PostType[], bottomRef: any }) 
           <Post key={id} id={id} title={title} userId={userId} body={body} />
         )
       }
+      {isFetching && Array(7).fill(0).map(_ => <SkeletonPost />)}
       <div ref={bottomRef} style={{ height: "0.5rem" }}></div>
     </div >
   );

--- a/src/components/Post/GridPosts.tsx
+++ b/src/components/Post/GridPosts.tsx
@@ -11,7 +11,7 @@ const GridPosts = ({ posts, bottomRef, isFetching }: { posts: PostType[], bottom
           <Post key={id} id={id} title={title} userId={userId} body={body} />
         )
       }
-      {isFetching && Array(7).fill(0).map(_ => <SkeletonPost />)}
+      {isFetching && Array(7).fill(0).map((_, idx) => <SkeletonPost key={idx} />)}
       <div ref={bottomRef} style={{ height: "0.5rem" }}></div>
     </div >
   );

--- a/src/components/Post/GridPosts.tsx
+++ b/src/components/Post/GridPosts.tsx
@@ -5,15 +5,17 @@ import SkeletonPost from '../Skeleton/SkeletonPost';
 
 const GridPosts = ({ posts, bottomRef, isFetching }: { posts: PostType[], bottomRef: any, isFetching: boolean }) => {
   return (
-    <div className="posts-wrapper">
-      {
-        posts.map(({ id, title, userId, body }: PostType) =>
-          <Post key={id} id={id} title={title} userId={userId} body={body} />
-        )
-      }
-      {isFetching && Array(7).fill(0).map((_, idx) => <SkeletonPost key={idx} />)}
+    <>
+      <div className="posts-wrapper">
+        {
+          posts.map(({ id, title, userId, body }: PostType) =>
+            <Post key={id} id={id} title={title} userId={userId} body={body} />
+          )
+        }
+        {isFetching && Array(7).fill(0).map((_, idx) => <SkeletonPost key={idx} />)}
+      </div >
       <div ref={bottomRef} style={{ height: "0.5rem" }}></div>
-    </div >
+    </>
   );
 };
 

--- a/src/components/Skeleton/SkeletonPost.scss
+++ b/src/components/Skeleton/SkeletonPost.scss
@@ -24,7 +24,7 @@
 
 .skeleton-post {
   &-wrapper {
-    width: 25rem;
+    width: calc(25rem - 2rem);
     display: flex;
     flex-direction: column;
     gap: 1rem;

--- a/src/components/Skeleton/SkeletonPost.scss
+++ b/src/components/Skeleton/SkeletonPost.scss
@@ -1,0 +1,53 @@
+@keyframes skeleton-shine-animation {
+  0% {
+    background-position-x: 100%;
+  }
+  40% {
+    background-position-x: -100%;
+  }
+  100% {
+    background-position-x: -100%;
+  }
+}
+
+.skeleton-animation {
+  background-image: linear-gradient(
+    110deg,
+    #dee2e6 8%,
+    #e9ecef 18%,
+    #dee2e6 33%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shine-animation 1.5s infinite linear;
+  border-radius: 5px;
+}
+
+.skeleton-post {
+  &-wrapper {
+    width: 25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin: 1rem;
+  }
+
+  &-header {
+    display: flex;
+    gap: 1rem;
+  }
+
+  &-title {
+    width: 80%;
+    height: 3rem;
+  }
+
+  &-user {
+    width: 20%;
+    height: 3rem;
+  }
+
+  &-section {
+    width: 100%;
+    height: 3rem;
+  }
+}

--- a/src/components/Skeleton/SkeletonPost.tsx
+++ b/src/components/Skeleton/SkeletonPost.tsx
@@ -1,0 +1,15 @@
+import './SkeletonPost.scss'
+
+const SkeletonPost = () => {
+  return (
+    <div className="skeleton-post-wrapper">
+      <header className="skeleton-post-header">
+        <div className="skeleton-post-title skeleton-animation" />
+        <div className="skeleton-post-user skeleton-animation" />
+      </header>
+      <section className="skeleton-post-section skeleton-animation" />
+    </div>
+  );
+};
+
+export default SkeletonPost;


### PR DESCRIPTION
# 문제점 1
* 간헐적으로 3*3에서 inView 정상적 체크가 되지 않는 현상 발생

# 해결 1 - [bottomRef를 Grid에서 분리](https://github.com/khw970421/react-query-posts/pull/9/commits/8a31fa62f5c3f4239906f087b3d797c1c293ced5) (23/5/12)
* Grid내에 Ref를 담당하는 부분이 존재하여 해당 부분을 Grid에서 빼내 처리 

# 문제점 2
* skeleton이 나타나면서 다른 width를 가진 skeleton으로 인해 기존 post들의 UI 레이아웃이 발생

# 해결 2 - [skeleton-wrapper width와 margin을 합쳐 25rem 처리](https://github.com/khw970421/react-query-posts/pull/9/commits/7ec91a5239155db1c734036fddb39eef0cca8fd0)
* skeleton은 `width : 25rem`에 `margin : 1rem`씩 들어가 있어 전체 영역 크기가 post와 다르므로 
`width+margin`을 25rem으로 `calc`를 사용하여 수정 