### PR TITLE
BottomSheet 디자인 및 오류 수정 

### DIFF
--- a/src/components/BottomSheet/ButtomSheet.scss
+++ b/src/components/BottomSheet/ButtomSheet.scss
@@ -20,6 +20,8 @@
   }
 
   &-header {
+    height: 4rem;
+
     display: flex;
     flex-direction: row;
     justify-content: space-between;
@@ -36,7 +38,7 @@
   }
 
   &-content {
-    height: 100%;
+    height: calc(100% - 4rem);
     overflow-y: auto;
   }
 }

--- a/src/components/BottomSheet/ButtomSheet.scss
+++ b/src/components/BottomSheet/ButtomSheet.scss
@@ -22,8 +22,14 @@
   &-header {
     display: flex;
     flex-direction: row;
-    justify-content: flex-end;
+    justify-content: space-between;
 
+    h3 {
+      padding: 0 1rem;
+      span {
+        font-weight: normal;
+      }
+    }
     button {
       background-color: $main-background;
     }

--- a/src/components/BottomSheet/ButtonSheet.tsx
+++ b/src/components/BottomSheet/ButtonSheet.tsx
@@ -1,16 +1,18 @@
 import './ButtomSheet.scss'
 
 interface ButtonSheetProps {
-  children: React.ReactNode;
+  children: React.ReactElement;
   className: string;
   closeButtonSheet: () => void
 }
 
 const ButtonSheet = (props: ButtonSheetProps) => {
   const { children, className, closeButtonSheet } = props
+  const commentLength = children.props?.comments?.length
   return (
     <div className={`bottom-sheet-wrapper ${className}`}>
       <header className="bottom-sheet-header">
+        <h3>게시물 댓글 <span>{commentLength}</span></h3>
         <button className="bottom-sheet-close-btn" onClick={closeButtonSheet}>X</button>
       </header>
       <div className="bottom-sheet-content">


### PR DESCRIPTION
* 기존에 header를 고정시키기 위해 `bottom-sheet-content`에서 header를 분리하였으나  
이로인해 content 영역이 header만큼을 제외하고 나타나여 마지막 comment가 나타나지 않는 현상 발생  

wrapper(500px) = header(65px) + content(100%로 500px) - header 영역으로 인해 보이지 않는 나머지 comment 영역(65px)

* header를 4rem을 주고 content를 calc를 이용해 `calc(100% - 4rem)`로 수정 