### PR TITLE
BottomSheet Close하고 난 후 오류 수정 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,7 @@ function App() {
 
   const handleCloseButtonSheet = () => {
     setIsModalOpen(false)
+    setSelectedPostId('')
   }
 
   useEffect(() => {


### PR DESCRIPTION
# 기존 문제점 
1. 같은 Post에 대해 댓글을 다시보려하면 댓글을 볼 수 없는 현상
2. 다른 window를 보다가 다시 해당 화면을 보면 댓글을 보지않는 화면인데도 댓글을 보는 화면으로 바뀌는 현상

# 문제 해결하기 (단편적인 생각)
* `refetchOnWindowFocus`를 false로 하면 2번 문제는 해결할 수 있지만, 이는 **근본적인 해결책**이 아니다. 

# 왜 이 문제가 발생할까?
* 이미 남아있는 `PostId`가 존재하기 때문이다. 
* 즉, close를 하고 PostId를 변경시켜줘야 1,2 모두 해결할 수 있다.

```js
const handleCloseButtonSheet = () => {
    setIsModalOpen(false)
    setSelectedPostId('')
  }
```
