### PR TITLE
Jest Testing 코드 작성 및 셀프 피드백 (⭐)

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test": "jest"
+    "test": "jest --watchAll"
   },
   "dependencies": {
     "@tanstack/react-query": "^4.29.5",
@@ -31,6 +31,7 @@
     "eslint": "^8.38.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.3.4",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "ts-jest": "^29.1.0",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,7 +1,0 @@
-// import App from "./App.tsx";
-import { render, screen } from '@testing-library/react'
-
-test('Renders main page correctly', () => {
-  render(<div>Hello, Jest!</div>);
-  expect(screen.getByText('Hello, Jest!')).toBeInTheDocument();
-});

--- a/src/__tests__/API.test.ts
+++ b/src/__tests__/API.test.ts
@@ -1,0 +1,9 @@
+import HttpInstance from '../api/user'
+
+HttpInstance.setUpInterceptors()
+
+test('postId toBe Same', async () => {
+  const postIdProp = 1
+  const { data } = await HttpInstance.getComments(postIdProp)
+  data.forEach(({ postId }: { postId: number }) => expect(postId).toBe(postIdProp))
+});

--- a/src/__tests__/Component.test.tsx
+++ b/src/__tests__/Component.test.tsx
@@ -1,0 +1,9 @@
+import Comment from "../components/Comment/Comment";
+import { render, screen } from '@testing-library/react'
+
+
+test('Comment text is correct', async () => {
+  render(<Comment name={"hi"} body={"this is body"} />);
+  expect(screen.getByText('this is body')).toBeInTheDocument();
+});
+

--- a/sum.test.js
+++ b/sum.test.js
@@ -1,7 +1,0 @@
-function sum(a, b) {
-  return a + b
-}
-
-test('adds 1 + 2 to equal 3', () => {
-  expect(sum(1, 2)).toBe(3)
-})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,6 +2153,11 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
+harmony-reflect@^1.4.6:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
+  integrity sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==
+
 has-bigints@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -2239,6 +2244,13 @@ iconv-lite@0.6.3:
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  integrity sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ignore@^5.2.0:
   version "5.2.4"


### PR DESCRIPTION
# test 코드 작성 
1. API 코드 
2. Component text 

# test를 통해 알게된 내용 
## 기존의 `getComment` (/api/user.ts)
```js
getComments(postId: string) {
    return this.axios.get(`comments?postId=${postId}`)
  }
```

* `postId`가 string 타입으로 생각을 하고 이에 따라 처리했었고 문제가 없었다. 
* 하지만 test 코드를 작성하고 동작하며 받아온 data의 postId와 비교를 진행했을 때 타입이 string과 number로 다른 것을 인지했다.

## 수정의 필요성 
* `getComment`의 props로 받는 `postId`는 string 타입이 아니라 number로 되어  
받아오는 postId 값과 같은 타입을 맞추는 것이 같은 의미를 갖는 **타입간의 안정성**에 필요하다고 생각한다.

# 결과 확인 내용 
##  문제 발생 
<img width="960" alt="problem" src="https://github.com/khw970421/react-query-posts/assets/59253551/c194383a-5bb0-40fc-9f77-ef48bd8c567e">

## 해결 Test 및 getComment 작성
<img width="949" alt="solved" src="https://github.com/khw970421/react-query-posts/assets/59253551/620d467f-9fa1-4475-9b3b-dce189693db6">

## 셀프 피드백 
* jest를 굳이 왜쓰지? 어떻게 써야하지? 라는 스스로의 의구심에서 이러한 문제점을 발견한 것이 해답을 주었다. 
* test를 하지않았다면 단지 Typescript를 썼으니 타입간 안정성이 충분하다고 안일하게 생각했을 것이다. 
실제 같은 의미를 갖는 `postId`여도 받아온 값과 전달되는 props간의 타입이 test전에는 다른지도 인지하지 못했을 것이다. 

# [관련 정리](https://khw970421.notion.site/Jest-CRA-68b5d8970e9f472d9b7de6420fdfa092) 
